### PR TITLE
Rename deprecated field

### DIFF
--- a/terraform/gcp/images-bucket.tf
+++ b/terraform/gcp/images-bucket.tf
@@ -3,7 +3,7 @@ resource "google_storage_bucket" "images" {
   location      = "ASIA-NORTHEAST1"
   force_destroy = true
 
-  bucket_policy_only = true
+  uniform_bucket_level_access = true
 }
 
 resource "google_storage_bucket_iam_policy" "images" {


### PR DESCRIPTION
https://github.com/yuya-takeyama/diagrasia/pull/106#commitcomment-42790786

>Warning: Deprecated Attribute

>  on images-bucket.tf line 6, in resource "google_storage_bucket" "images":
   6:   bucket_policy_only = true

>Please use the uniform_bucket_level_access as this field has been renamed by
Google.